### PR TITLE
Migrate to firebase for real-time shortcut streaming

### DIFF
--- a/firestore-extension-demo/README.md
+++ b/firestore-extension-demo/README.md
@@ -1,0 +1,41 @@
+# Firestore Sync Demo (Chrome MV3)
+
+Streams a Firestore collection into `chrome.storage.local` via an offscreen document and displays it in a popup.
+
+## Setup
+1. Fill `src/firebaseConfig.json` with your Web App config.
+2. Choose `collectionPath`:
+   - `snippets` (top-level collection), or
+   - `users/{uid}/snippets` (per-user subcollection), or
+   - `demo/default/snippets` (3 segments)
+3. Enable Authentication (Anonymous for the demo) in Firebase Console.
+4. Optional: Firestore rules for quick testing
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} { allow read: if request.auth != null; }
+  }
+}
+```
+
+## Build
+```
+npm install
+npm run build
+```
+Load `public/` as an unpacked extension in `chrome://extensions`.
+
+## How it works
+- `background.js` ensures an offscreen document exists
+- `offscreen.js` listens to Firestore, posts data via `chrome.runtime.sendMessage({ type: 'firestore-data' })`
+- `background.js` writes the payload into `chrome.storage.local` and broadcasts `snippets-updated`
+- `popup.js` reads `chrome.storage.local` and updates UI
+
+## Troubleshooting
+- Invalid collection reference: use a path with an odd number of segments (collection path)
+- `auth/configuration-not-found`: enable chosen auth provider or adjust rules
+- `Cannot read properties of undefined (reading 'local')`:
+  - Ensure you are loading `public/` (built JS). Do not open HTML files directly.
+  - The offscreen page now posts to background which writes storage.
+- Still failing? Open `service worker` and `offscreen` console from `chrome://extensions` → Details → Inspect views.

--- a/firestore-extension-demo/esbuild.mjs
+++ b/firestore-extension-demo/esbuild.mjs
@@ -1,0 +1,25 @@
+import { build } from 'esbuild';
+import { rmSync, mkdirSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const outdir = 'public';
+rmSync(outdir, { recursive: true, force: true });
+mkdirSync(outdir, { recursive: true });
+
+await build({
+  entryPoints: {
+    background: 'src/background.ts',
+    offscreen: 'src/offscreen.ts',
+    popup: 'src/popup.ts'
+  },
+  bundle: true,
+  format: 'esm',
+  outdir,
+  target: 'chrome120',
+  sourcemap: true
+});
+
+for (const f of ['manifest.json', 'offscreen.html', 'popup.html', 'firebaseConfig.json']) {
+  copyFileSync(join('src', f), join(outdir, f));
+}
+console.log('Built to', outdir);

--- a/firestore-extension-demo/package.json
+++ b/firestore-extension-demo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "firestore-extension-demo",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/firestore-extension-demo/package.json
+++ b/firestore-extension-demo/package.json
@@ -1,12 +1,17 @@
 {
   "name": "firestore-extension-demo",
-  "version": "1.0.0",
-  "main": "index.js",
+  "version": "0.1.1",
+  "private": true,
+  "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "node esbuild.mjs",
+    "clean": "rimraf public"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": ""
+  "dependencies": {
+    "firebase": "^10.12.5"
+  },
+  "devDependencies": {
+    "esbuild": "^0.21.5",
+    "rimraf": "^5.0.0"
+  }
 }

--- a/firestore-extension-demo/src/background.ts
+++ b/firestore-extension-demo/src/background.ts
@@ -25,6 +25,6 @@ chrome.runtime.onMessage.addListener((msg) => {
 		const data = msg.payload?.data || {};
 		const path = msg.payload?.path || '';
 		chrome.storage.local.set({ firestoreSnippets: data, updatedAt: Date.now(), sourcePath: path });
-		chrome.runtime.sendMessage({ type: 'snippets-updated' });
+		chrome.runtime.sendMessage({ type: 'snippets-updated' }, () => { void chrome.runtime.lastError; });
 	}
 });

--- a/firestore-extension-demo/src/background.ts
+++ b/firestore-extension-demo/src/background.ts
@@ -1,0 +1,24 @@
+async function ensureOffscreen() {
+	try {
+		const has = (chrome.offscreen && 'hasDocument' in chrome.offscreen)
+			? await (chrome.offscreen as any).hasDocument()
+			: false;
+		if (!has) {
+			await chrome.offscreen.createDocument({
+				url: 'offscreen.html',
+				reasons: ['DOM_PARSER'],
+				justification: 'Keep Firestore websocket alive for realtime sync'
+			});
+		}
+	} catch (err) {
+		console.warn('ensureOffscreen error:', err);
+	}
+}
+
+chrome.runtime.onInstalled.addListener(() => { ensureOffscreen(); });
+chrome.runtime.onStartup.addListener(() => { ensureOffscreen(); });
+ensureOffscreen();
+
+chrome.runtime.onMessage.addListener((msg) => {
+	if (msg?.type === 'log') console.log('[offscreen]', msg.payload);
+});

--- a/firestore-extension-demo/src/background.ts
+++ b/firestore-extension-demo/src/background.ts
@@ -21,4 +21,10 @@ ensureOffscreen();
 
 chrome.runtime.onMessage.addListener((msg) => {
 	if (msg?.type === 'log') console.log('[offscreen]', msg.payload);
+	if (msg?.type === 'firestore-data') {
+		const data = msg.payload?.data || {};
+		const path = msg.payload?.path || '';
+		chrome.storage.local.set({ firestoreSnippets: data, updatedAt: Date.now(), sourcePath: path });
+		chrome.runtime.sendMessage({ type: 'snippets-updated' });
+	}
 });

--- a/firestore-extension-demo/src/firebaseConfig.json
+++ b/firestore-extension-demo/src/firebaseConfig.json
@@ -1,0 +1,8 @@
+{
+	"apiKey": "REPLACE",
+	"authDomain": "REPLACE.firebaseapp.com",
+	"projectId": "REPLACE",
+	"appId": "REPLACE",
+	"collectionPath": "demo/snippets",
+	"auth": { "method": "anonymous" }
+}

--- a/firestore-extension-demo/src/manifest.json
+++ b/firestore-extension-demo/src/manifest.json
@@ -1,0 +1,9 @@
+{
+	"manifest_version": 3,
+	"name": "Firestore Sync Demo",
+	"version": "0.1.1",
+	"description": "Streams a Firestore collection into chrome.storage via an offscreen document and shows data in popup.",
+	"permissions": ["storage", "offscreen"],
+	"background": { "service_worker": "background.js", "type": "module" },
+	"action": { "default_popup": "popup.html" }
+}

--- a/firestore-extension-demo/src/manifest.json
+++ b/firestore-extension-demo/src/manifest.json
@@ -4,6 +4,11 @@
 	"version": "0.1.1",
 	"description": "Streams a Firestore collection into chrome.storage via an offscreen document and shows data in popup.",
 	"permissions": ["storage", "offscreen"],
+	"host_permissions": [
+		"https://*.googleapis.com/*",
+		"https://*.gstatic.com/*",
+		"https://*.firebaseio.com/*"
+	],
 	"background": { "service_worker": "background.js", "type": "module" },
 	"action": { "default_popup": "popup.html" }
 }

--- a/firestore-extension-demo/src/offscreen.html
+++ b/firestore-extension-demo/src/offscreen.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+	<head><meta charset="utf-8" /></head>
+	<body>
+		<script type="module" src="offscreen.js"></script>
+	</body>
+</html>

--- a/firestore-extension-demo/src/offscreen.ts
+++ b/firestore-extension-demo/src/offscreen.ts
@@ -1,5 +1,5 @@
 import { initializeApp } from 'firebase/app';
-import { getFirestore, enableIndexedDbPersistence, collection, onSnapshot } from 'firebase/firestore';
+import { getFirestore, enableIndexedDbPersistence, collection, onSnapshot, initializeFirestore } from 'firebase/firestore';
 import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
 import rawConfig from './firebaseConfig.json' assert { type: 'json' };
 
@@ -8,7 +8,8 @@ const collectionPathTemplate: string = config.collectionPath || 'snippets';
 const authMethod: string = config.auth?.method || 'anonymous';
 
 const app = initializeApp(config);
-const db = getFirestore(app);
+// Use longPolling to avoid WebChannel transport issues behind proxies/VPNs
+const db = initializeFirestore(app, { experimentalForceLongPolling: true });
 const auth = getAuth(app);
 
 try { await enableIndexedDbPersistence(db); } catch {}
@@ -35,9 +36,9 @@ async function start(uid: string) {
 	onSnapshot(colRef, (qs) => {
 		const data: Record<string, any> = {};
 		qs.forEach((doc) => { data[doc.id] = doc.data(); });
-		chrome.runtime.sendMessage({ type: 'firestore-data', payload: { data, path } });
+		chrome.runtime.sendMessage({ type: 'firestore-data', payload: { data, path } }).catch(() => {});
 	}, (err) => {
-		chrome.runtime.sendMessage({ type: 'log', payload: `onSnapshot error: ${err}` });
+		chrome.runtime.sendMessage({ type: 'log', payload: `onSnapshot error: ${err}` }).catch(() => {});
 	});
 }
 

--- a/firestore-extension-demo/src/offscreen.ts
+++ b/firestore-extension-demo/src/offscreen.ts
@@ -1,0 +1,48 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore, enableIndexedDbPersistence, collection, onSnapshot } from 'firebase/firestore';
+import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
+import rawConfig from './firebaseConfig.json' assert { type: 'json' };
+
+const config = rawConfig as any;
+const collectionPathTemplate: string = config.collectionPath || 'demo/snippets';
+const authMethod: string = config.auth?.method || 'anonymous';
+
+const app = initializeApp(config);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+try { await enableIndexedDbPersistence(db); } catch {}
+
+async function ensureAuth(): Promise<string> {
+	if (authMethod === 'anonymous') {
+		const user = auth.currentUser;
+		if (user) return user.uid;
+		const cred = await signInAnonymously(auth);
+		return cred.user.uid;
+	}
+	return new Promise<string>((resolve) => {
+		const unsub = onAuthStateChanged(auth, (u) => { if (u) { unsub(); resolve(u.uid); } });
+	});
+}
+
+function resolvePath(uid: string): string {
+	return collectionPathTemplate.replace('{uid}', uid);
+}
+
+async function start(uid: string) {
+	const path = resolvePath(uid);
+	const colRef = collection(db, path);
+	onSnapshot(colRef, (qs) => {
+		const data: Record<string, any> = {};
+		qs.forEach((doc) => { data[doc.id] = doc.data(); });
+		chrome.storage.local.set({ firestoreSnippets: data, updatedAt: Date.now(), sourcePath: path });
+		chrome.runtime.sendMessage({ type: 'snippets-updated' });
+	}, (err) => {
+		chrome.runtime.sendMessage({ type: 'log', payload: `onSnapshot error: ${err}` });
+	});
+}
+
+(async () => {
+	const uid = await ensureAuth();
+	start(uid);
+})();

--- a/firestore-extension-demo/src/offscreen.ts
+++ b/firestore-extension-demo/src/offscreen.ts
@@ -4,7 +4,7 @@ import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
 import rawConfig from './firebaseConfig.json' assert { type: 'json' };
 
 const config = rawConfig as any;
-const collectionPathTemplate: string = config.collectionPath || 'demo/snippets';
+const collectionPathTemplate: string = config.collectionPath || 'snippets';
 const authMethod: string = config.auth?.method || 'anonymous';
 
 const app = initializeApp(config);
@@ -35,8 +35,7 @@ async function start(uid: string) {
 	onSnapshot(colRef, (qs) => {
 		const data: Record<string, any> = {};
 		qs.forEach((doc) => { data[doc.id] = doc.data(); });
-		chrome.storage.local.set({ firestoreSnippets: data, updatedAt: Date.now(), sourcePath: path });
-		chrome.runtime.sendMessage({ type: 'snippets-updated' });
+		chrome.runtime.sendMessage({ type: 'firestore-data', payload: { data, path } });
 	}, (err) => {
 		chrome.runtime.sendMessage({ type: 'log', payload: `onSnapshot error: ${err}` });
 	});

--- a/firestore-extension-demo/src/popup.html
+++ b/firestore-extension-demo/src/popup.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<style>
+			body { font-family: system-ui, sans-serif; margin: 12px; width: 380px; }
+			pre { white-space: pre-wrap; word-break: break-word; background: #f6f8fa; padding: 8px; border-radius: 6px; }
+			.row { display:flex; gap:8px; align-items:center; }
+			button { padding:6px 10px; }
+			small { color: #666; }
+			code { background: #eee; padding: 1px 4px; border-radius: 4px; }
+		</style>
+	</head>
+	<body>
+		<h3>Firestore Sync Demo</h3>
+		<div class="row">
+			<button id="refresh">Refresh</button>
+			<small id="status"></small>
+		</div>
+		<div><small>Path: <code id="path"></code></small></div>
+		<pre id="output">No data yet</pre>
+		<script type="module" src="popup.js"></script>
+	</body>
+</html>

--- a/firestore-extension-demo/src/popup.ts
+++ b/firestore-extension-demo/src/popup.ts
@@ -1,0 +1,17 @@
+function setOutput(obj: any) {
+	const pre = document.getElementById('output')!;
+	pre.textContent = JSON.stringify(obj, null, 2);
+}
+
+async function refresh() {
+	const data = await chrome.storage.local.get(['firestoreSnippets', 'updatedAt', 'sourcePath']);
+	setOutput(data.firestoreSnippets || {});
+	(document.getElementById('status')!).textContent = data.updatedAt ? `Updated: ${new Date(data.updatedAt).toLocaleTimeString()}` : '';
+	(document.getElementById('path')!).textContent = data.sourcePath || '';
+}
+
+chrome.runtime.onMessage.addListener((msg) => { if (msg?.type === 'snippets-updated') refresh(); });
+
+document.getElementById('refresh')!.addEventListener('click', refresh);
+
+refresh();

--- a/firestore-extension-demo/src/popup.ts
+++ b/firestore-extension-demo/src/popup.ts
@@ -4,10 +4,14 @@ function setOutput(obj: any) {
 }
 
 async function refresh() {
-	const data = await chrome.storage.local.get(['firestoreSnippets', 'updatedAt', 'sourcePath']);
-	setOutput(data.firestoreSnippets || {});
-	(document.getElementById('status')!).textContent = data.updatedAt ? `Updated: ${new Date(data.updatedAt).toLocaleTimeString()}` : '';
-	(document.getElementById('path')!).textContent = data.sourcePath || '';
+	try {
+		const data = await chrome.storage?.local?.get?.(['firestoreSnippets', 'updatedAt', 'sourcePath']);
+		setOutput((data && data.firestoreSnippets) || {});
+		(document.getElementById('status')!).textContent = data?.updatedAt ? `Updated: ${new Date(data.updatedAt).toLocaleTimeString()}` : '';
+		(document.getElementById('path')!).textContent = data?.sourcePath || '';
+	} catch (e) {
+		setOutput({ error: String(e) });
+	}
 }
 
 chrome.runtime.onMessage.addListener((msg) => { if (msg?.type === 'snippets-updated') refresh(); });


### PR DESCRIPTION
Implements a Chrome MV3 extension demo to synchronize Firestore data to `chrome.storage.local` via an offscreen document. This enables real-time, zero-latency local data access for features like text replacement.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2c5c806-a712-4486-bdca-52ec9c3b6d49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2c5c806-a712-4486-bdca-52ec9c3b6d49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

